### PR TITLE
8285357: Update .jcheck/conf file for 7u move to git

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -1,2 +1,31 @@
-project=jdk7
-bugids=dup
+[general]
+project=jdk7u
+jbs=JDK
+version=openjdk7u341
+
+[checks]
+error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace
+
+[repository]
+tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
+branches=
+
+[census]
+version=0
+domain=openjdk.org
+
+[checks "whitespace"]
+files=.*\.cpp|.*\.hpp|.*\.c|.*\.h|.*\.java
+
+[checks "merge"]
+message=Merge
+
+[checks "reviewers"]
+reviewers=1
+ignore=duke
+
+[checks "committer"]
+role=committer
+
+[checks "issues"]
+pattern=^([124-8][0-9]{6}): (\S.*)$


### PR DESCRIPTION
We have to update the .jcheck/conf for jdk7u in the same manner as it was done for jdk8u-dev: https://github.com/openjdk/jdk8u-dev/commit/4a19c1a65107202800bf8df51684f7255d6ef027

The current version for 7u is openjdk7u341.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285357](https://bugs.openjdk.java.net/browse/JDK-8285357): Update .jcheck/conf file for 7u move to git


### Reviewers
 * [Yuri Nesterenko](https://openjdk.java.net/census#yan) (@yan-too - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk7u pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.java.net/jdk7u pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk7u/pull/1.diff">https://git.openjdk.java.net/jdk7u/pull/1.diff</a>

</details>
