### PR TITLE
8285726: [11u, 17u] Unify fix for JDK-8284548 with version from head

### DIFF
--- a/jdk/test/javax/xml/jaxp/XPath/InvalidXPath.java
+++ b/jdk/test/javax/xml/jaxp/XPath/InvalidXPath.java
@@ -36,18 +36,26 @@ public class InvalidXPath {
 
     public static void main(String... args) {
         // define an invalid XPath expression
-        final String invalidXPath = ">>";
+        final String[] invalidXPath = {
+            // @bug JDK-8284548: expressions ending with relational operators
+            // throw StringIndexOutOfBoundsException instead of XPathExpressionException
+            "/a/b/c[@d >",
+            "/a/b/c[@d <",
+            "/a/b/c[@d >=",
+            ">>"
+        };
 
-        // expect XPathExpressionException when the invalid XPath expression is compiled
-        try {
-            XPathFactory.newInstance().newXPath().compile(invalidXPath);
-        } catch (XPathExpressionException e) {
-            System.out.println("Caught expected exception: " + e.getClass().getName() +
-                    "(" + e.getMessage() + ").");
-        } catch (Exception e) {
-            System.out.println("Caught unexpected exception: " + e.getClass().getName() +
-                    "(" + e.getMessage() + ")!");
-            throw e;
+        for(String s: invalidXPath) {
+            try {
+                XPathFactory.newInstance().newXPath().compile(s);
+            } catch (XPathExpressionException e) {
+                System.out.println("Caught expected exception: " + e.getClass().getName() +
+                        "(" + e.getMessage() + ").");
+            } catch (Exception e) {
+                System.out.println("Caught unexpected exception: " + e.getClass().getName() +
+                        "(" + e.getMessage() + ")!");
+                throw e;
+            }
         }
     }
 }


### PR DESCRIPTION
This fix is different from versions 8+: first, in Lexer.java there's no LastModified and a usual copyright, so it is dropped from the change. Second, a new XPathExceptionTest is hard to compile in 7: to run with jdk7 we'd need an older than usual version of testng which, in turn, doesn't work with asserts like that in the test, there are lambdas, and XPathExpression has no used or similar method. Instead of of backporting the test, I'm doing a simple change in existing one.

Thus, test-only update change. Test pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285726](https://bugs.openjdk.java.net/browse/JDK-8285726): [11u, 17u] Unify fix for JDK-8284548 with version from head ⚠️ Issue is not open.


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk7u pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.java.net/jdk7u pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk7u/pull/3.diff">https://git.openjdk.java.net/jdk7u/pull/3.diff</a>

</details>
