### PR TITLE
8087283: Add support for the XML Signature here() function to the JDK XPath implementation

### DIFF
--- a/jaxp/src/com/sun/org/apache/xpath/internal/compiler/FunctionTable.java
+++ b/jaxp/src/com/sun/org/apache/xpath/internal/compiler/FunctionTable.java
@@ -1,21 +1,23 @@
 /*
- * reserved comment block
- * DO NOT REMOVE OR ALTER!
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
  */
-/*
- * Copyright 1999-2005 The Apache Software Foundation.
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 /*
  * $Id: FunctionTable.java,v 1.3 2005/09/28 13:49:34 pvedula Exp $
@@ -135,6 +137,9 @@ public class FunctionTable
   /** The 'unparsed-entity-uri()' id (XSLT). */
   public static final int FUNC_UNPARSED_ENTITY_URI = 36;
 
+  /** The 'here()' id (XML Signature). */
+  public static final int FUNC_HERE = 37;
+
   // Proprietary
 
   /** The 'document-location()' id (Proprietary). */
@@ -162,7 +167,7 @@ public class FunctionTable
    * Number of built in functions.  Be sure to update this as
    * built-in functions are added.
    */
-  private static final int NUM_BUILT_IN_FUNCS = 37;
+  private static final int NUM_BUILT_IN_FUNCS = 38;
 
   /**
    * Number of built-in functions that may be added.
@@ -229,6 +234,8 @@ public class FunctionTable
       com.sun.org.apache.xpath.internal.functions.FuncDoclocation.class;
     m_functions[FUNC_UNPARSED_ENTITY_URI] =
       com.sun.org.apache.xpath.internal.functions.FuncUnparsedEntityURI.class;
+    m_functions[FUNC_HERE] =
+      com.sun.org.apache.xpath.internal.functions.FuncHere.class;
   }
 
   static{
@@ -302,6 +309,8 @@ public class FunctionTable
                           new Integer(FunctionTable.FUNC_UNPARSED_ENTITY_URI));
           m_functionID.put(Keywords.FUNC_DOCLOCATION_STRING,
                           new Integer(FunctionTable.FUNC_DOCLOCATION));
+          m_functionID.put(Keywords.FUNC_HERE_STRING,
+                          new Integer(FunctionTable.FUNC_HERE));
   }
 
   public FunctionTable(){

--- a/jaxp/src/com/sun/org/apache/xpath/internal/compiler/Keywords.java
+++ b/jaxp/src/com/sun/org/apache/xpath/internal/compiler/Keywords.java
@@ -326,6 +326,9 @@ public class Keywords {
     public static final String FUNC_UNPARSED_ENTITY_URI_STRING
             = "unparsed-entity-uri";
 
+  /** here function string (XML Signature). */
+  public static final String FUNC_HERE_STRING = "here";
+
   // Proprietary, built in functions
     /**
      * current function string (Proprietary).

--- a/jaxp/src/com/sun/org/apache/xpath/internal/functions/FuncHere.java
+++ b/jaxp/src/com/sun/org/apache/xpath/internal/functions/FuncHere.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sun.org.apache.xpath.internal.functions;
+
+import javax.xml.transform.TransformerException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import com.sun.org.apache.xml.internal.dtm.DTM;
+import com.sun.org.apache.xpath.internal.NodeSetDTM;
+import com.sun.org.apache.xpath.internal.XPathContext;
+import com.sun.org.apache.xpath.internal.objects.XNodeSet;
+import com.sun.org.apache.xpath.internal.objects.XObject;
+import com.sun.org.apache.xpath.internal.res.XPATHErrorResources;
+
+/**
+ * Execute the XML Signature here() function.
+ */
+public final class FuncHere extends Function {
+
+    private static final long serialVersionUID = 4328660760070034592L;
+
+    @Override
+    public XObject execute(XPathContext xctxt) throws TransformerException {
+        Node xpathOwnerNode = (Node)xctxt.getOwnerObject();
+        if (xpathOwnerNode == null) {
+            return null;
+        }
+
+        int xpathOwnerNodeDTM = xctxt.getDTMHandleFromNode(xpathOwnerNode);
+        int currentNode = xctxt.getCurrentNode();
+        DTM dtm = xctxt.getDTM(currentNode);
+        int docContext = dtm.getDocument();
+
+        if (docContext == DTM.NULL) {
+            error(xctxt, XPATHErrorResources.ER_CONTEXT_HAS_NO_OWNERDOC, null);
+        }
+
+        // check whether currentNode and the node containing the XPath
+        // expression are in the same document
+        Document currentDoc = getOwnerDocument(dtm.getNode(currentNode));
+        Document xpathOwnerDoc = getOwnerDocument(xpathOwnerNode);
+
+        if (currentDoc != xpathOwnerDoc) {
+            throw new TransformerException("Owner documents differ");
+        }
+
+        XNodeSet nodes = new XNodeSet(xctxt.getDTMManager());
+        NodeSetDTM nodeSet = nodes.mutableNodeset();
+
+        int hereNode = DTM.NULL;
+
+        switch (dtm.getNodeType(xpathOwnerNodeDTM)) {
+
+            case Node.ATTRIBUTE_NODE:
+            case Node.PROCESSING_INSTRUCTION_NODE: {
+                // returns a node-set containing the attribute /  processing
+                // instruction node
+                hereNode = xpathOwnerNodeDTM;
+                nodeSet.addNode(hereNode);
+                break;
+            }
+            case Node.TEXT_NODE : {
+                // returns a node-set containing the parent element of the
+                // text node that directly bears the XPath expression
+                hereNode = dtm.getParent(xpathOwnerNodeDTM);
+                nodeSet.addNode(hereNode);
+                break;
+            }
+            default :
+                break;
+        }
+
+        /** $todo$ Do I have to do this detach() call? */
+        nodeSet.detach();
+
+        return nodes;
+    }
+
+    private static Document getOwnerDocument(Node node) {
+        if (node.getNodeType() == Node.DOCUMENT_NODE) {
+            return (Document)node;
+        }
+        return node.getOwnerDocument();
+    }
+
+    @Override
+    public void fixupVariables(java.util.Vector vars, int globalsSize) { }
+}


### PR DESCRIPTION
I need to backport this change to 7u to facilitate other updates. Tests run fine (with testng 6)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8087283](https://bugs.openjdk.java.net/browse/JDK-8087283): Add support for the XML Signature here() function to the JDK XPath implementation


### Reviewers
 * [Andrew Brygin](https://openjdk.java.net/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk7u pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jdk7u pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk7u/pull/6.diff">https://git.openjdk.java.net/jdk7u/pull/6.diff</a>

</details>
