### PR TITLE
8289907: Add missed jdk/src/share part of 8087283

### DIFF
--- a/jdk/src/share/classes/com/sun/org/apache/xml/internal/security/utils/XalanXPathAPI.java
+++ b/jdk/src/share/classes/com/sun/org/apache/xml/internal/security/utils/XalanXPathAPI.java
@@ -167,6 +167,14 @@ public class XalanXPathAPI implements XPathAPI {
 
     private synchronized static void fixupFunctionTable() {
         installed = false;
+        if (new FunctionTable().functionAvailable("here")) {
+            if (log.isLoggable(java.util.logging.Level.FINE)) {
+                log.log(java.util.logging.Level.FINE, "Here function already registered");
+            }
+            installed = true;
+            return;
+        }
+        
         if (log.isLoggable(java.util.logging.Level.FINE)) {
             log.log(java.util.logging.Level.FINE, "Registering Here function");
         }

--- a/jdk/src/share/classes/com/sun/org/apache/xml/internal/security/utils/XalanXPathAPI.java
+++ b/jdk/src/share/classes/com/sun/org/apache/xml/internal/security/utils/XalanXPathAPI.java
@@ -174,7 +174,7 @@ public class XalanXPathAPI implements XPathAPI {
             installed = true;
             return;
         }
-        
+
         if (log.isLoggable(java.util.logging.Level.FINE)) {
             log.log(java.util.logging.Level.FINE, "Registering Here function");
         }


### PR DESCRIPTION
It is a missed part of 8087283 cleanup fix. It has in head the same bug id and synopsis: I hope  Skara jcheck would process it.
... UPDATE: bugid changed to a new 8289907 to keep it more conventional

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289907](https://bugs.openjdk.org/browse/JDK-8289907): Add missed jdk/src/share part of 8087283


### Reviewers
 * [Andrew Brygin](https://openjdk.org/census#bae) (@bae - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk7u pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/jdk7u pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk7u/pull/7.diff">https://git.openjdk.org/jdk7u/pull/7.diff</a>

</details>
