### PR TITLE
8285523: Improve test java/io/FileOutputStream/OpenNUL.java

### DIFF
--- a/jdk/src/windows/classes/java/io/Win32FileSystem.java
+++ b/jdk/src/windows/classes/java/io/Win32FileSystem.java
@@ -51,16 +51,15 @@ class Win32FileSystem extends FileSystem {
 
     // Whether to enable alternative data streams (ADS) by suppressing
     // checking the path for invalid characters, in particular ":".
-    // ADS support will be enabled if and only if the property is set and
-    // is the empty string or is equal, ignoring case, to the string "true".
-    // By default ADS support is disabled.
+    // By default, ADS support is enabled and will be disabled if and
+    // only if the property is set, ignoring case, to the string "false".
     private static final boolean ENABLE_ADS;
     static {
         String enableADS = GetPropertyAction.privilegedGetProperty("jdk.io.File.enableADS");
         if (enableADS != null) {
-            ENABLE_ADS = "".equals(enableADS) || Boolean.parseBoolean(enableADS);
+            ENABLE_ADS = !enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
         } else {
-            ENABLE_ADS = false;
+            ENABLE_ADS = true;
         }
     }
 

--- a/jdk/test/java/io/FileOutputStream/OpenNUL.java
+++ b/jdk/test/java/io/FileOutputStream/OpenNUL.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8285445
+ * @requires (os.family == "windows")
+ * @summary Verify behavior of opening "NUL:" with ADS enabled and disabled.
+ * @run main/othervm -Djdk.io.File.enableADS OpenNUL
+ * @run main/othervm -Djdk.io.File.enableADS=true OpenNUL
+ */
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class OpenNUL {
+    public static void main(String args[]) throws IOException {
+        String enableADS = System.getProperty("jdk.io.File.enableADS");
+        boolean fails = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
+
+        FileOutputStream fos;
+        try {
+            fos = new FileOutputStream("NUL:");
+            if (fails)
+                throw new RuntimeException("Should have failed");
+        } catch (FileNotFoundException fnfe) {
+            if (!fails)
+                throw new RuntimeException("Should not have failed");
+        }
+    }
+}

--- a/jdk/test/java/io/FileOutputStream/OpenNUL.java
+++ b/jdk/test/java/io/FileOutputStream/OpenNUL.java
@@ -26,7 +26,9 @@
  * @bug 8285445
  * @requires (os.family == "windows")
  * @summary Verify behavior of opening "NUL:" with ADS enabled and disabled.
+ * @run main/othervm OpenNUL
  * @run main/othervm -Djdk.io.File.enableADS OpenNUL
+ * @run main/othervm -Djdk.io.File.enableADS=FalsE OpenNUL
  * @run main/othervm -Djdk.io.File.enableADS=true OpenNUL
  */
 
@@ -36,7 +38,7 @@ import java.io.IOException;
 
 public class OpenNUL {
     public static void main(String args[]) throws IOException {
-        String enableADS = System.getProperty("jdk.io.File.enableADS");
+        String enableADS = System.getProperty("jdk.io.File.enableADS", "true");
         boolean fails = enableADS.equalsIgnoreCase(Boolean.FALSE.toString());
 
         FileOutputStream fos;


### PR DESCRIPTION
I'd like to backport JDK-8285523 to jdk7u.

The patch applied not cleanly due to the directory structure differences:
`test/jdk/java/io/FileOutputStream/OpenNUL.java`-> `jdk/test/java/io/FileOutputStream/OpenNUL.java`

Tested manually as follow:
$JTREG_HOME/bin/jtreg -jdk:$BUILD_HOME /cygdrive/c/projects/jdk7u-fork/jdk/test/java/io/
No regression in the above tests' group.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285523](https://bugs.openjdk.org/browse/JDK-8285523): Improve test java/io/FileOutputStream/OpenNUL.java


### Reviewers
 * [Andrew Brygin](https://openjdk.org/census#bae) (@bae - **Reviewer**) ⚠️ Review applies to [412cd71d](https://git.openjdk.org/jdk7u/pull/10/files/412cd71d6c0144526bd0d8d96c027963b86691e1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk7u pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jdk7u pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk7u/pull/10.diff">https://git.openjdk.org/jdk7u/pull/10.diff</a>

</details>
